### PR TITLE
Correct handling when Forest Fire stops before reaching the required nb of nodes

### DIFF
--- a/littleballoffur/exploration_sampling/forestfiresampler.py
+++ b/littleballoffur/exploration_sampling/forestfiresampler.py
@@ -49,19 +49,22 @@ class ForestFireSampler(Sampler):
         node_queue = deque([seed_node])
         while len(self._sampled_nodes) < self.number_of_nodes:
             if len(node_queue) == 0:
-                node_queue = [self._visited_nodes.popleft()
-                              for k in range(min(self.restart_hop_size, len(self._visited_nodes)))]
-
+                node_queue = deque([self._visited_nodes.popleft()
+                              for k in range(min(self.restart_hop_size, len(self._visited_nodes)))])
+                if len(node_queue) == 0:
+                    print('Warning: could not collect the required number of nodes. The fire could not find enough nodes to burn.')
+                    break
             top_node = node_queue.popleft()
             self._sampled_nodes.add(top_node)
             neighbors = set(self.backend.get_neighbors(graph, top_node))
             unvisited_neighbors = neighbors.difference(self._sampled_nodes)
             score = np.random.geometric(self.p)
             count = min(len(unvisited_neighbors), score)
-            neighbors = random.sample(unvisited_neighbors, count)
-            self._visited_nodes.extendleft(unvisited_neighbors.difference(set(neighbors)))
-            for neighbor in neighbors:
+            burned_neighbors = random.sample(unvisited_neighbors, count)
+            self._visited_nodes.extendleft(unvisited_neighbors.difference(set(burned_neighbors)))
+            for neighbor in burned_neighbors:
                 if len(self._sampled_nodes) >= self.number_of_nodes:
+                    print('break')
                     break
                 node_queue.extend([neighbor])
 

--- a/littleballoffur/exploration_sampling/forestfiresampler.py
+++ b/littleballoffur/exploration_sampling/forestfiresampler.py
@@ -64,7 +64,6 @@ class ForestFireSampler(Sampler):
             self._visited_nodes.extendleft(unvisited_neighbors.difference(set(burned_neighbors)))
             for neighbor in burned_neighbors:
                 if len(self._sampled_nodes) >= self.number_of_nodes:
-                    print('break')
                     break
                 node_queue.extend([neighbor])
 


### PR DESCRIPTION
Added a missing 'deque' to turn the list into a queue and a check if this new list is empty (in case there are no neighbors to propagate to).