### PR TITLE
Add dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@ from setuptools import find_packages, setup
 
 on_rtd = os.environ.get("READTHEDOCS") == "True"
 
-install_requires = ["networkx",
+install_requires = ['cmake',
+                    'Cython',
+                    "networkx",
                     "tqdm",
                     "python-louvain",
                     "pandas",


### PR DESCRIPTION
Add Cython and cmake to dependencies. Networkit relies on these but leaves installation for the user. Without these the installation of littleballoffur fails unless the user has Cython and cmake installed already.