### PR TITLE
Unpinning dependencies to upgrade various including networkx 3.0

### DIFF
--- a/littleballoffur/backend.py
+++ b/littleballoffur/backend.py
@@ -69,13 +69,13 @@ class NetworKitBackEnd(object):
         """
         Given a graph and node return the neighbors.
         """
-        return graph.neighbors(node)
+        return [node for node in graph.iterNeighbors(node)]
 
     def get_random_neighbor(self, graph: NKGraph, node: int) -> int:
         """
         Given a graph and node returns a random neighbor.
         """
-        return graph.randomNeighbor(node)
+        return nk.graphtools.randomNeighbor(graph, node)
 
     def get_shortest_path(self, graph: NKGraph, source: int, target: int) -> List[int]:
         """

--- a/littleballoffur/backend.py
+++ b/littleballoffur/backend.py
@@ -1,9 +1,9 @@
 import random
-import numpy as np
-import networkx as nx
-import networkit as nk
 from typing import List, Tuple
 
+import networkit as nk
+import networkx as nx
+import numpy as np
 
 NKGraph = type(nk.graph.Graph())
 NXGraph = nx.classes.graph.Graph
@@ -13,6 +13,7 @@ class NetworKitBackEnd(object):
     """
     Binding the NetworKit backend to serve graph operations.
     """
+
     def __init__(self):
         pass
 
@@ -22,13 +23,11 @@ class NetworKitBackEnd(object):
         """
         return graph.numberOfNodes()
 
-
     def get_number_of_edges(self, graph: NKGraph) -> int:
         """
         Given a graph return the number of edges.
         """
         return graph.numberOfEdges()
-
 
     def get_nodes(self, graph: NKGraph) -> List:
         """
@@ -36,13 +35,11 @@ class NetworKitBackEnd(object):
         """
         return graph.nodes()
 
-
     def get_edges(self, graph: NKGraph) -> List[Tuple]:
         """
         Given a graph return the edges.
         """
         return graph.edges()
-
 
     def get_node_iterator(self, graph: NKGraph):
         """
@@ -50,13 +47,11 @@ class NetworKitBackEnd(object):
         """
         return graph.iterNodes()
 
-
     def get_edge_iterator(self, graph: NKGraph):
         """
         Given a graph return the edge iterator.
         """
         return graph.iterEdges()
-
 
     def get_degree(self, graph: NKGraph, node: int) -> int:
         """
@@ -64,13 +59,11 @@ class NetworKitBackEnd(object):
         """
         return graph.degree(node)
 
-
     def get_subgraph(self, graph: NKGraph, nodes: List[int]) -> NKGraph:
         """
         Given a graph and set of inducing nodes return a subgraph.
         """
         return graph.subgraphFromNodes(nodes)
-
 
     def get_neighbors(self, graph: NKGraph, node: int) -> List[int]:
         """
@@ -78,20 +71,17 @@ class NetworKitBackEnd(object):
         """
         return graph.neighbors(node)
 
-
     def get_random_neighbor(self, graph: NKGraph, node: int) -> int:
         """
         Given a graph and node returns a random neighbor.
         """
         return graph.randomNeighbor(node)
 
-
     def get_shortest_path(self, graph: NKGraph, source: int, target: int) -> List[int]:
         """
         Given a graph, a source and target node pair get the shortes path
         """
         return nk.distance.ReverseBFS(graph, source, True, False, target).run().getPath(target)
-
 
     def get_pagerank(self, graph: NKGraph, alpha: float) -> np.array:
         """
@@ -118,30 +108,25 @@ class NetworKitBackEnd(object):
             new_graph.addEdge(edge[0], edge[1], addMissing=True)
         return new_graph
 
-
     def _check_networkit_graph(self, graph: NKGraph):
         """Chechking the input type."""
         assert isinstance(graph, NKGraph), "This is not a NetworKit graph."
-
 
     def _check_connectivity(self, graph: NKGraph):
         """Checking the connected nature of a single graph."""
         connected = nk.components.ConnectedComponents(graph).run().numberOfComponents()
         assert connected == 1, "Graph is not connected."
 
-
     def _check_directedness(self, graph: NXGraph):
         """Checking the undirected nature of a single graph."""
         directed = graph.isDirected()
         assert directed == False, "Graph is directed."
-
 
     def _check_indexing(self, graph: NKGraph):
         """Checking the consecutive numeric indexing."""
         numeric_indices = [index for index in range(graph.numberOfNodes())]
         node_indices = sorted([node for node in graph.nodes()])
         assert numeric_indices == node_indices, "The node indexing is wrong."
-
 
     def check_graph(self, graph: NKGraph):
         """Check the Little Ball of Fur assumptions about the graph."""
@@ -154,9 +139,9 @@ class NetworkXBackEnd(object):
     """
     Binding the NetworkX backend to serve graph operations.
     """
+
     def __init__(self):
         pass
-
 
     def get_number_of_nodes(self, graph: NXGraph) -> int:
         """
@@ -164,13 +149,11 @@ class NetworkXBackEnd(object):
         """
         return graph.number_of_nodes()
 
-
     def get_number_of_edges(self, graph: NXGraph) -> int:
         """
         Given a graph return the number of edges.
         """
         return graph.number_of_edges()
-
 
     def get_nodes(self, graph: NXGraph) -> List:
         """
@@ -178,13 +161,11 @@ class NetworkXBackEnd(object):
         """
         return [node for node in graph.nodes()]
 
-
     def get_edges(self, graph: NXGraph) -> List[Tuple]:
         """
         Given a graph return the edges.
         """
         return [edge for edge in graph.edges()]
-
 
     def get_node_iterator(self, graph: NXGraph):
         """
@@ -192,13 +173,11 @@ class NetworkXBackEnd(object):
         """
         return graph.nodes()
 
-
     def get_edge_iterator(self, graph: NXGraph):
         """
         Given a graph return the edge iterator.
         """
         return graph.edges()
-
 
     def get_degree(self, graph: NXGraph, node: int) -> int:
         """
@@ -206,20 +185,17 @@ class NetworkXBackEnd(object):
         """
         return graph.degree[node]
 
-
     def get_subgraph(self, graph: NXGraph, nodes: List[int]) -> NXGraph:
         """
         Given a graph and set of inducing nodes return a subgraph.
         """
         return graph.subgraph(nodes)
 
-
     def get_neighbors(self, graph: NXGraph, node: int) -> List[int]:
         """
         Given a graph and node return the neighbors.
         """
         return [node for node in graph.neighbors(node)]
-
 
     def get_random_neighbor(self, graph: NXGraph, node: int) -> int:
         """
@@ -228,19 +204,17 @@ class NetworkXBackEnd(object):
         neighbors = self.get_neighbors(graph, node)
         return random.choice(neighbors)
 
-
     def get_shortest_path(self, graph: NXGraph, source: int, target: int) -> List[int]:
         """
         Given a graph, a source and target node pair get the shortes path
         """
         return nx.shortest_path(graph, source, target)
 
-
     def get_pagerank(self, graph: NXGraph, alpha: float) -> np.array:
         """
         Given a graph return the PageRank vector.
         """
-        pagerank = nx.pagerank_scipy(graph, alpha=alpha)
+        pagerank = nx.pagerank(graph, alpha=alpha)
         pagerank = np.array([pagerank[node] for node in graph.nodes()])
         pagerank = pagerank / pagerank.sum()
         return pagerank
@@ -249,7 +223,7 @@ class NetworkXBackEnd(object):
         return nx.is_weighted(graph)
 
     def get_edge_weight(self, graph: NXGraph, u: int, v: int) -> float:
-        return graph.get_edge_data(u, v)['weight']
+        return graph.get_edge_data(u, v)["weight"]
 
     def graph_from_edgelist(self, edges: List) -> NXGraph:
         """
@@ -258,30 +232,25 @@ class NetworkXBackEnd(object):
         graph = nx.from_edgelist(edges)
         return graph
 
-
     def _check_networkx_graph(self, graph: NXGraph):
         """Chechking the input type."""
         assert isinstance(graph, NXGraph), "This is not a NetworkX graph."
-
 
     def _check_connectivity(self, graph: NXGraph):
         """Checking the connected nature of a single graph."""
         connected = nx.is_connected(graph)
         assert connected, "Graph is not connected."
 
-
     def _check_directedness(self, graph: NXGraph):
         """Checking the undirected nature of a single graph."""
         directed = nx.is_directed(graph)
         assert directed == False, "Graph is directed."
-
 
     def _check_indexing(self, graph: NXGraph):
         """Checking the consecutive numeric indexing."""
         numeric_indices = [index for index in range(graph.number_of_nodes())]
         node_indices = sorted([node for node in graph.nodes()])
         assert numeric_indices == node_indices, "The node indexing is wrong."
-
 
     def check_graph(self, graph: NXGraph):
         """Check the Little Ball of Fur assumptions about the graph."""

--- a/littleballoffur/backend.py
+++ b/littleballoffur/backend.py
@@ -33,13 +33,13 @@ class NetworKitBackEnd(object):
         """
         Given a graph return the nodes.
         """
-        return graph.nodes()
+        return [node for node in self.get_node_iterator(graph)]
 
     def get_edges(self, graph: NKGraph) -> List[Tuple]:
         """
         Given a graph return the edges.
         """
-        return graph.edges()
+        return [edge for edge in self.get_edge_iterator(graph)]
 
     def get_node_iterator(self, graph: NKGraph):
         """

--- a/littleballoffur/backend.py
+++ b/littleballoffur/backend.py
@@ -5,7 +5,18 @@ import networkit as nk
 import networkx as nx
 import numpy as np
 
-NKGraph = type(nk.graph.Graph())
+
+class NetworKitGraph(nx.graph.Graph):
+    """Subclass of nx.graph.Graph with .nodes/edges() methods."""
+
+    def nodes(self):
+        return [node for node in self.iterNodes()]
+
+    def edges(self):
+        return [edge for edge in self.iterEdges()]
+
+
+NKGraph = NetworKitGraph
 NXGraph = nx.classes.graph.Graph
 
 

--- a/littleballoffur/backend.py
+++ b/littleballoffur/backend.py
@@ -63,7 +63,7 @@ class NetworKitBackEnd(object):
         """
         Given a graph and set of inducing nodes return a subgraph.
         """
-        return graph.subgraphFromNodes(nodes)
+        return nk.graphtools.subgraphFromNodes(graph, nodes)
 
     def get_neighbors(self, graph: NKGraph, node: int) -> List[int]:
         """

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,28 @@
 import os
+
 from setuptools import find_packages, setup
 
 on_rtd = os.environ.get("READTHEDOCS") == "True"
 
-install_requires = ["numpy<1.23.0",
-                    "networkx<2.7",
-                    "decorator==4.4.2",
-                    "cmake",
-                    "Cython",
-                    "tqdm",
-                    "python-louvain",
-                    "pandas<=1.3.5",
-                    "six",
-                    "scipy"]
+install_requires = [
+    "numpy",
+    "networkx",
+    "decorator",
+    "cmake",
+    "Cython",
+    "tqdm",
+    "python-louvain",
+    "pandas",
+    "six",
+    "scipy",
+]
 
 if not on_rtd:
-    install_requires.append("networkit==7.1")
+    install_requires.append("networkit")
 
 setup_requires = ["cython", "numpy", "pytest-runner"]
 
 tests_require = ["pytest", "pytest-cov", "mock", "unittest"]
-
 
 
 keywords = [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     "Cython",
     "tqdm",
     "python-louvain",
-    "pandas",
+    "pandas<2.0",
     "six",
     "scipy",
 ]

--- a/test/backend_test.py
+++ b/test/backend_test.py
@@ -1,10 +1,10 @@
-import networkx as nx
 import networkit as nk
+import networkx as nx
+
 from littleballoffur import NetworKitBackEnd, NetworkXBackEnd
 
 
 def test_networkit_backend_basics():
-
     backend = NetworKitBackEnd()
     graph = nk.generators.WattsStrogatzGenerator(1000, 10, 0.0).generate()
 
@@ -14,10 +14,10 @@ def test_networkit_backend_basics():
 
 
 def test_networkit_backend_get_basics():
-
     backend = NetworKitBackEnd()
-    graph = nk.graph.Graph()
+    graph = nk.graph.Graph(directed=False)
 
+    # addMissing adds missing nodes
     graph.addEdge(0, 1, addMissing=True)
     graph.addEdge(1, 2, addMissing=True)
     graph.addEdge(2, 3, addMissing=True)
@@ -34,15 +34,15 @@ def test_networkit_backend_get_basics():
     assert 4 in nodes
     assert 5 in nodes
 
-    assert (1, 0) in edges
-    assert (2, 1) in edges
-    assert (3, 2) in edges
-    assert (4, 2) in edges
-    assert (5, 2) in edges
+    # Edges are always sorted low to high.
+    assert (0, 1) in edges
+    assert (1, 2) in edges
+    assert (2, 3) in edges
+    assert (2, 4) in edges
+    assert (2, 5) in edges
 
 
 def test_networkit_backend_graph_from_edgelist():
-
     backend = NetworKitBackEnd()
     graph = backend.graph_from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -64,7 +64,6 @@ def test_networkit_backend_graph_from_edgelist():
 
 
 def test_networkit_backend_get_iterator():
-
     backend = NetworKitBackEnd()
     graph = nk.graph.Graph()
 
@@ -81,7 +80,6 @@ def test_networkit_backend_get_iterator():
 
 
 def test_networkit_backend_induction():
-
     backend = NetworKitBackEnd()
     graph = nk.graph.Graph()
 
@@ -100,7 +98,6 @@ def test_networkit_backend_induction():
 
 
 def test_networkit_backend_neighbors():
-
     backend = NetworKitBackEnd()
     graph = nk.graph.Graph()
 
@@ -126,7 +123,6 @@ def test_networkit_backend_neighbors():
 
 
 def test_networkit_backend_shortest_path():
-
     backend = NetworKitBackEnd()
 
     graph = nk.graph.Graph()
@@ -144,7 +140,6 @@ def test_networkit_backend_shortest_path():
 
 
 def test_networkit_backend_pagerank():
-
     backend = NetworKitBackEnd()
     graph = nk.generators.WattsStrogatzGenerator(1000, 10, 0.0).generate()
 
@@ -154,7 +149,6 @@ def test_networkit_backend_pagerank():
 
 
 def test_networkx_backend_basics():
-
     backend = NetworkXBackEnd()
     graph = nx.watts_strogatz_graph(1000, 10, 0.0)
 
@@ -164,7 +158,6 @@ def test_networkx_backend_basics():
 
 
 def test_networkx_backend_get_basics():
-
     backend = NetworkXBackEnd()
     graph = nx.from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -186,7 +179,6 @@ def test_networkx_backend_get_basics():
 
 
 def test_networkx_backend_iterator_basics():
-
     backend = NetworkXBackEnd()
     graph = nx.from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -198,7 +190,6 @@ def test_networkx_backend_iterator_basics():
 
 
 def test_networkx_backend_induction():
-
     backend = NetworkXBackEnd()
     graph = nx.from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -212,7 +203,6 @@ def test_networkx_backend_induction():
 
 
 def test_networkx_backend_neighbors():
-
     backend = NetworkXBackEnd()
     graph = nx.from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -232,7 +222,6 @@ def test_networkx_backend_neighbors():
 
 
 def test_networkx_backend_shortest_path():
-
     backend = NetworkXBackEnd()
     graph = nx.from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -244,7 +233,6 @@ def test_networkx_backend_shortest_path():
 
 
 def test_networkx_backend_pagerank():
-
     backend = NetworkXBackEnd()
     graph = nx.watts_strogatz_graph(1000, 10, 0.0)
 
@@ -254,7 +242,6 @@ def test_networkx_backend_pagerank():
 
 
 def test_networkx_backend_graph_from_edgelist():
-
     backend = NetworkXBackEnd()
     graph = backend.graph_from_edgelist([[0, 1], [1, 2], [2, 3], [2, 4], [2, 5]])
 
@@ -272,4 +259,5 @@ def test_networkx_backend_graph_from_edgelist():
     assert (1, 2) in edges
     assert (2, 3) in edges
     assert (2, 4) in edges
+    assert (2, 5) in edges
     assert (2, 5) in edges

--- a/test/backend_test.py
+++ b/test/backend_test.py
@@ -260,4 +260,3 @@ def test_networkx_backend_graph_from_edgelist():
     assert (2, 3) in edges
     assert (2, 4) in edges
     assert (2, 5) in edges
-    assert (2, 5) in edges

--- a/test/backend_test.py
+++ b/test/backend_test.py
@@ -56,11 +56,11 @@ def test_networkit_backend_graph_from_edgelist():
     assert 4 in nodes
     assert 5 in nodes
 
-    assert (1, 0) in edges
-    assert (2, 1) in edges
-    assert (3, 2) in edges
-    assert (4, 2) in edges
-    assert (5, 2) in edges
+    assert (0, 1) in edges
+    assert (1, 2) in edges
+    assert (2, 3) in edges
+    assert (2, 4) in edges
+    assert (2, 5) in edges
 
 
 def test_networkit_backend_get_iterator():


### PR DESCRIPTION
Just getting started here... my dependency versions are:

```python
cmake==3.26.4
Cython==0.29.35
decorator==5.1.1
exceptiongroup==1.1.1
iniconfig==2.0.0
littleballoffur==2.2.0
networkit==10.1
networkx==3.1
numpy==1.25.0rc1
packaging==23.1
pandas==1.5.3
pluggy==1.0.0
pytest==7.3.1
python-dateutil==2.8.2
python-louvain==0.16
pytz==2023.3
scipy==1.11.0rc1
six==1.16.0
tomli==2.0.1
tqdm==4.65.0
tzdata==2023.3
```