### PR TITLE
Add README.md contents to PyPi package web page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.8",
     ],
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
Put the contents of the [README.md](README.md) up on the package PyPi page at [https://pypi.org/project/littleballoffur/](https://pypi.org/project/littleballoffur/) so it will search engine optimization (SEO) better and more people will find and use it. As a side benefit, automated systems that evaluate open-source projects will rate the project higher.

cc @benedekrozemberczki an easy one to merge :)